### PR TITLE
use more effecient Files.copy method

### DIFF
--- a/src/main/scala/ru/company/project/Main.scala
+++ b/src/main/scala/ru/company/project/Main.scala
@@ -25,7 +25,7 @@ object Main {
   }
 
   def copyToLocal(file: Path): Unit = {
-    val localFile = Paths.get(".", file.toString().substring(1));
+    val localFile = Paths.get(".", file.toString.substring(1));
     Files.createDirectories(localFile.getParent());
     Files.copy(file, localFile);
   }

--- a/src/main/scala/ru/company/project/Main.scala
+++ b/src/main/scala/ru/company/project/Main.scala
@@ -25,9 +25,8 @@ object Main {
   }
 
   def copyToLocal(file: Path): Unit = {
-    val content = Files.readAllLines(file)
-    val localFSFile = FileSystems.getDefault.getPath(file.toString.substring(1))
-    localFSFile.toFile.getParentFile.mkdirs()
-    Files.write(localFSFile, content)
+    val localFile = Paths.get(".", file.toString().substring(1));
+    Files.createDirectories(localFile.getParent());
+    Files.copy(file, localFile);
   }
 }


### PR DESCRIPTION
This change uses the method `Files.copy(...)`, which is more effecient and can also handle binary files.
In addition, `Files.createDirectories(...)` is used to create non-existing folders to avoid fall-back to the old `java.io.File` API.
(Please note that this code is not tested, nor is it guaranteed, that it even compiles.)